### PR TITLE
add the docker_layer_caching key to docker_layer_caching

### DIFF
--- a/src/lib/Components/Commands/schemas/Native/SetupRemoteDocker.schema.ts
+++ b/src/lib/Components/Commands/schemas/Native/SetupRemoteDocker.schema.ts
@@ -5,6 +5,9 @@ const SetupRemoteDockerSchema: SchemaObject = {
   type: ['object', 'null'],
   additionalProperties: false,
   properties: {
+    docker_layer_caching: {
+      type: 'boolean',
+    },
     version: {
       type: 'string',
     },


### PR DESCRIPTION
there is currently a mismatch between the circleci docks and the schema. 
![image](https://github.com/CircleCI-Public/circleci-config-parser-ts/assets/7240295/04b7ba2f-0d97-4750-b7b8-55c525379298)
